### PR TITLE
update notifier endpoints for airbrake-crystal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ rescue ex : DivisionByZero
   Airbrake.notify(ex)
 end
 
-puts 'Check your dashboard on https://airbrake.io'
+puts 'Check your dashboard on https://app.airbrake.io'
 ```
 
 Configuration

--- a/spec/airbrake_spec.cr
+++ b/spec/airbrake_spec.cr
@@ -12,11 +12,11 @@ describe Airbrake do
     end
 
     it "sends notices" do
-      WebMock.stub(:post, "https://airbrake.io/api/v3/projects/#{id}/notices?key=#{key}").
-        to_return(body: %({"id":"1","url":"https://airbrake.io/locate/1"}))
+      WebMock.stub(:post, "https://app.airbrake.io/api/v3/projects/#{id}/notices?key=#{key}").
+        to_return(body: %({"id":"1","url":"https://app.airbrake.io/locate/1"}))
 
       retval = Airbrake.notify(AirbrakeTestError.new)
-      retval.should eq({"id" => "1", "url" => "https://airbrake.io/locate/1"})
+      retval.should eq({"id" => "1", "url" => "https://app.airbrake.io/locate/1"})
     end
 
     it "raises error if project_key is missing" do

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -22,7 +22,7 @@ describe Airbrake::Config do
       end
 
       uri = Airbrake.config.uri.to_s
-      uri.should eq("https://airbrake.io/api/v3/projects/#{id}/notices?key=#{key}")
+      uri.should eq("https://app.airbrake.io/api/v3/projects/#{id}/notices?key=#{key}")
     end
   end
 end


### PR DESCRIPTION
This PR updates the endpoints for the notifier from airbrake.io to app.airbrake.io. This is due to an upcoming change in how airbrake handles requests and routing. 